### PR TITLE
Map modmasks for CTRL+ALT & SUPER+ALT

### DIFF
--- a/nix/binds.nix
+++ b/nix/binds.nix
@@ -13,9 +13,11 @@ let
     "4" = "CTRL+";
     "5" = "SHIFT+CTRL+";
     "8" = "ALT+";
+    "12" = "CTRL+ALT";
     "64" = "SUPER+";
     "65" = "SUPER+SHIFT+";
     "68" = "SUPER+CTRL+";
+    "72" = "SUPER+ALT+";
   };
   keycodes = {
     "59" = "Comma";


### PR DESCRIPTION
These binds:
```
bind = CTRL+ALT, S, exec, $fuzzel || $scripts/fuzzel-set-audio-sink
bind = SUPER ALT, 1, movetoworkspacesilent, 1
bind = SUPER ALT, 2, movetoworkspacesilent, 2
...
```
end up as null when run with this program:
<img width="1723" height="573" alt="image" src="https://github.com/user-attachments/assets/866986e6-ac82-4e34-a5b1-19e618091027" />

Contributing the missing modmasks.