### PR TITLE
Support for Fuzzel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Keybinds helper for Hyprland.
 
 ## How to use
 
-The `hypr-binds` program is mainly customizable via Home Manager (see below), but a program with sane defaults both for [Wofi](https://sr.ht/~scoopta/wofi/) and [Rofi](https://github.com/davatorium/rofi) is provided out of the box for *all Linux users*.
+The `hypr-binds` program is mainly customizable via Home Manager (see below), but a program with sane defaults for [Wofi](https://sr.ht/~scoopta/wofi/), [Rofi](https://github.com/davatorium/rofi), and [Fuzzel](https://codeberg.org/dnkl/fuzzel) are provided out of the box for *all Linux users*.
 
 ## Nix support
  
@@ -69,7 +69,7 @@ It comes with defaults, but it's possible to customize it:
     enable = true;
     settings = {
       launcher = {
-        app = "wofi"; # or rofi
+        app = "wofi"; # or rofi or fuzzel
         style = {
           modkey = "<b>$MOD$KEY</b> <i>$DESCRIPTION</i>";
           command = "cyan";
@@ -83,7 +83,7 @@ It comes with defaults, but it's possible to customize it:
 
 ## General support
 
-The same script one can run via `nix` is also generally available for all non-nix users as simple bash scripts where the only hard dependencies are `bash` and [jq](https://github.com/jqlang/jq), besides either Wofi or Rofi.
+The same script one can run via `nix` is also generally available for all non-nix users as simple bash scripts where the only hard dependencies are `bash` and [jq](https://github.com/jqlang/jq), besides Wofi, Rofi, or Fuzzel.
 
 Users are welcome to download either script and modify it at will:
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
 
           hypr-binds-wofi = buildPkg { };
           hypr-binds-rofi = buildPkg { launcher = "rofi"; };
+          hypr-binds-fuzzel = buildPkg { launcher = "fuzzel"; };
         in
         {
           homeManagerModules.default = {
@@ -23,7 +24,7 @@
 
           packages = {
             default = hypr-binds-wofi;
-            inherit hypr-binds-wofi hypr-binds-rofi;
+            inherit hypr-binds-wofi hypr-binds-rofi hypr-binds-fuzzel;
           };
         }
       );

--- a/nix/binds.nix
+++ b/nix/binds.nix
@@ -23,20 +23,45 @@ let
     "59" = "Comma";
     "60" = "Dot";
   };
+  launcherConfigs = {
+    fuzzel = {
+      cmd = "${lib.getExe pkgs.fuzzel} --dmenu --width=100 -p 'Hypr binds '";
+      # Fuzzel doesn't support pango formatting
+      style = ''\(.mod)\(if .key == "" then .code else .key end) | \(.desc) | \(.dp) \(.arg)'';
+      pipeline = cmd: ''column -t -s '|' | ${cmd}'';
+      extract = ''sed -n 's/.*  \([^ ].*\)$/\1/p' '';
+    };
 
-  launcherCommand =
-    if launcher == "rofi"
-    then "${lib.getExe pkgs.rofi} -dmenu -markup-rows -i -p 'Hypr binds'"
-    else "${lib.getExe pkgs.wofi} --dmenu -m -i -p 'Hypr binds'";
+    wofi = {
+      cmd = "${lib.getExe pkgs.wofi} --dmenu -m -i -p 'Hypr binds'";
+      style =
+        let
+          modkey = builtins.replaceStrings
+            [ "$MOD" "$KEY" "$DESCRIPTION" ]
+            [ "\\(.mod)" "\\(if .key == \"\" then .code else .key end)" "\\(.desc)" ]
+            modkeyStyle;
+        in
+        ''${modkey} <span color=\"${cmdcolor}\">\(.dp) \(.arg)</span>'';
+      pipeline = cmd: cmd;
+      extract = ''sed -n 's/.*<span color=\"${cmdcolor}\">\(.*\)<\/span>.*/\1/p' '';
+    };
 
-  style =
-    let
-      modkey = builtins.replaceStrings
-        [ "$MOD" "$KEY" "$DESCRIPTION" ]
-        [ "\\(.mod)" "\\(if .key == \"\" then .code else .key end)" "\\(.desc)" ]
-        modkeyStyle;
-    in
-    ''${modkey} <span color=\"${cmdcolor}\">\(.dp) \(.arg)</span>'';
+    rofi = {
+      cmd = "${lib.getExe pkgs.rofi} -dmenu -markup-rows -i -p 'Hypr binds'";
+      style =
+        let
+          modkey = builtins.replaceStrings
+            [ "$MOD" "$KEY" "$DESCRIPTION" ]
+            [ "\\(.mod)" "\\(if .key == \"\" then .code else .key end)" "\\(.desc)" ]
+            modkeyStyle;
+        in
+        ''${modkey} <span color=\"${cmdcolor}\">\(.dp) \(.arg)</span>'';
+      pipeline = cmd: cmd;
+      extract = ''sed -n 's/.*<span color=\"${cmdcolor}\">\(.*\)<\/span>.*/\1/p' '';
+    };
+  };
+
+  config = launcherConfigs.${launcher} or launcherConfigs.wofi;
 in
 writeShellScriptBin "hypr-binds" ''
   hyprctl binds -j |
@@ -46,13 +71,11 @@ writeShellScriptBin "hypr-binds" ''
       map(.code |= ${builtins.toJSON keycodes} [.]) |
       sort_by(.mod) | .[] |
       select(.sub == "") |
-      "${style}" ' | ${launcherCommand} |
-    # extract the command (dispatcher + arg)
-    sed -n 's/.*<span color=\"${cmdcolor}\">\(.*\)<\/span>.*/\1/p' |
+      "${config.style}" ' |
+    ${config.pipeline config.cmd} |
+    ${config.extract} |
     ${if dispatch then ''
-      # add double quotes to the string so it can be piped to hyprctl dispatch
       sed -e 's/^/"/g' -e 's/$/"/g' |
       xargs -n1 hyprctl dispatch
-      '' else "xargs"
-    }
+    '' else "xargs"}
 ''

--- a/nix/hm.nix
+++ b/nix/hm.nix
@@ -14,7 +14,7 @@ in
     settings = {
       launcher = {
         app = mkOption {
-          type = types.enum [ "rofi" "wofi" ];
+          type = types.enum [ "rofi" "wofi" "fuzzel" ];
           description = "The launcher application";
           default = "wofi";
         };


### PR DESCRIPTION
Adds support for using [fuzzel](https://codeberg.org/dnkl/fuzzel) as a launcher. It also makes the launcher config a bit more modular so future launchers should be easier to add.