### PR TITLE
Update binds.nix

### DIFF
--- a/nix/binds.nix
+++ b/nix/binds.nix
@@ -13,7 +13,8 @@ let
     "4" = "CTRL+";
     "5" = "SHIFT+CTRL+";
     "8" = "ALT+";
-    "12" = "CTRL+ALT";
+    "9" = "SHIFT+ALT+";
+    "12" = "CTRL+ALT+";
     "64" = "SUPER+";
     "65" = "SUPER+SHIFT+";
     "68" = "SUPER+CTRL+";


### PR DESCRIPTION
Managed to typo (missing a `+`) in previous PR #4 
Also noticed SHIFT+ALT+ missing.